### PR TITLE
3 Tiny Changes

### DIFF
--- a/slimCat/ViewModels/Base Classes/ChannelViewModelBase.cs
+++ b/slimCat/ViewModels/Base Classes/ChannelViewModelBase.cs
@@ -303,6 +303,8 @@ namespace slimCat.ViewModels
             if (Message == null)
                 return;
 
+            Message = Message.Trim();
+
             if (CommandParser.HasNonCommand(Message))
             {
                 SendMessage();

--- a/slimCat/Views/Channel Bar/SearchTabView.xaml
+++ b/slimCat/Views/Channel Bar/SearchTabView.xaml
@@ -63,6 +63,7 @@
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
             </Expander>
+            <Line Stretch="Fill" Stroke="{StaticResource HighlightBrush}" X2="1" Margin="0,10" />
         </StackPanel>
 
         <StackPanel DockPanel.Dock="Bottom">
@@ -76,9 +77,6 @@
 
         <ScrollViewer CanContentScroll="False">
             <StackPanel>
-
-
-                <Line Stretch="Fill" Stroke="{StaticResource HighlightBrush}" X2="1" Margin="0,10" />
 
                 <ItemsControl ItemsSource="{Binding Path=AvailableSearchTerms, Mode=OneWay}"
                               Style="{StaticResource HorizontalListBoxStyle}">

--- a/slimCat/Views/Channels/PMChannelView.xaml.cs
+++ b/slimCat/Views/Channels/PMChannelView.xaml.cs
@@ -108,9 +108,14 @@ namespace slimCat.Views
 
         private void OnSelected(object sender, RoutedEventArgs e)
         {
-            if (isAdded) return;
+            if (isAdded)
+            {
+                Reader.Document.BringIntoView(); // Scrolls to top, where the image is
+                return;
+            }
 
             ProfileParagraph.Inlines.InsertBefore(ProfileParagraph.Inlines.FirstInline, lastItem);
+            Reader.Document.BringIntoView(); // Scrolls to top, where the image is
 
             isAdded = true;
         }


### PR DESCRIPTION
Each file is 1 separate change.
ChannelViewModelBase.cs = Whitespace trimmed around edges
SearchTabView.xaml = The middle horizontal separator does not vanish
when the lower portion of the tab is scrolled down
PMChannelView.xaml.cs = When viewing a profile, clicking an image's
thumbnail automatically scrolls to top, immediately viewing the full
image
