### PR TITLE
Touchups on /me and similar commands

### DIFF
--- a/slimCat/Models/CommandDefinitions.cs
+++ b/slimCat/Models/CommandDefinitions.cs
@@ -145,10 +145,15 @@ namespace slimCat.Models
 
         public static readonly IDictionary<string, CommandModel> Commands = new Dictionary<string, CommandModel>();
 
-        public static readonly string[] NonCommandCommands =
+        // prevents long ugly checking in our viewmodels for these
+        public static readonly Dictionary<string, Func<string, string>> NonCommandCommands = new Dictionary<string, Func<string, string>>()
         {
-            // prevents long ugly checking in our viewmodels for these
-            "/me ", "/me'", "/my ", "/warn ", "/post "
+            {"/me ",   (x) => { if (x[4]=='\'') return x.Substring("/me ".Length);
+                                           else return x.Substring("/me".Length); }},
+            {"/me's ", (x) => x.Substring("/me".Length)},
+            {"/my ",   (x) => "'s" + x.Substring("/my".Length)},
+            {"/post ", (x) => x.Substring("/post".Length) + " ~"},
+            {"/warn ", (x) => " warns," + x.Substring("/warn".Length)}
         };
 
         public static readonly IDictionary<string, string> CommandAliases = new Dictionary<string, string>();

--- a/slimCat/Services/LoggingService.cs
+++ b/slimCat/Services/LoggingService.cs
@@ -127,40 +127,18 @@ namespace slimCat.Services
             {
                 var thisMessage = HttpUtility.HtmlDecode(message.Message);
                 var timestamp = message.TimeStamp;
+
                 switch (message.Type)
                 {
                     case MessageType.Normal:
-                        if (thisMessage[0] != '/')
-                            writer.WriteLine(timestamp + ' ' + message.Poster.Name + ": " + thisMessage);
+                        var logMessage = timestamp + ' ' + message.Poster.Name;
+                        var check = thisMessage.Substring(0, thisMessage.IndexOf(' ') + 1);
+                        Func<string, string> nonCommandCommand;
+
+                        if (CommandDefinitions.NonCommandCommands.TryGetValue(check, out nonCommandCommand))
+                            writer.WriteLine(logMessage + nonCommandCommand(thisMessage));
                         else
-                        {
-                            string messageStart = message.Message.Substring(0, 4);
-                            switch (messageStart)
-                            {
-                                case "/me ":
-                                    if (thisMessage[4] == '\'')
-                                        writer.WriteLine(timestamp + ' ' + message.Poster.Name + thisMessage.Substring(4));
-                                    else
-                                        writer.WriteLine(timestamp + ' ' + message.Poster.Name + thisMessage.Substring(3));
-                                    break;
-                                case "/me'":
-                                    writer.WriteLine(timestamp + ' ' + message.Poster.Name + thisMessage.Substring(3));
-                                    break;
-                                case "/my ":
-                                    writer.WriteLine(timestamp + ' ' + message.Poster.Name +
-                                    "'s" + thisMessage.Substring(3));
-                                    break;
-                                case "/pos":
-                                    if (thisMessage.StartsWith("/post "))
-                                    {
-                                        writer.WriteLine(timestamp + ' ' + message.Poster.Name + thisMessage.Substring(5) + " ~");
-                                    }
-                                    break;
-                                default:
-                                    writer.WriteLine(timestamp + ' ' + message.Poster.Name + ": " + thisMessage);
-                                    break;
-                            }
-                        }
+                            writer.WriteLine(logMessage + ": " + thisMessage);
                         break;
                     case MessageType.Roll:
                         writer.WriteLine(timestamp + ' ' + thisMessage);
@@ -169,10 +147,8 @@ namespace slimCat.Services
                         if (!message.Message.StartsWith("/me "))
                             writer.WriteLine("Ad at " + timestamp + ": " + thisMessage + " ~By " + message.Poster.Name);
                         else
-                        {
                             writer.WriteLine(
-                            "Ad at " + timestamp + ": " + message.Poster.Name + " " + thisMessage.Substring(3));
-                        }
+                                "Ad at " + timestamp + ": " + message.Poster.Name + thisMessage.Substring(3));
                         break;
                 }
             }

--- a/slimCat/Utilities/CommandParser.cs
+++ b/slimCat/Utilities/CommandParser.cs
@@ -131,7 +131,7 @@ namespace slimCat.Utilities
         /// </param>
         public static bool HasNonCommand(string input)
         {
-            return CommandDefinitions.NonCommandCommands.Any(input.StartsWith);
+            return CommandDefinitions.NonCommandCommands.Keys.Any(input.StartsWith);
         }
 
         /// <summary>

--- a/slimCat/Views/UI Parts/ChannelMessageView.xaml
+++ b/slimCat/Views/UI Parts/ChannelMessageView.xaml
@@ -45,6 +45,7 @@
                                         RelativeSource={RelativeSource AncestorType={x:Type FlowDocument}}}"
                           CommandParameter="{Binding Path=Poster.Name, Mode=OneTime}" />
         </Hyperlink.InputBindings>
+    <!--Below line is written like this to prevent XML from automatically adding a space here-->
     </Hyperlink><Span
         lib:SpanHelper.InlineSource="{Binding Mode=OneTime, Converter={StaticResource BbFlowConverter}, IsAsync=True}" />
 </Paragraph>


### PR DESCRIPTION
Incomplete /me and /warn commands now fail, and commands like /meow
aren't interpreted as a /me command
Commands like /me's paws, /my paws now appear as "Name's paws" without a
space after the Name

These commands should function as you'd expect in both chat and logs:
/me /me's /me 's /my /post /warn
