### PR TITLE
Empty tooltips on kinks & images don't appear

### DIFF
--- a/slimCat/Theme/EmbeddedTheme.xaml
+++ b/slimCat/Theme/EmbeddedTheme.xaml
@@ -21,6 +21,7 @@
     <utilities:MessageThicknessConverter x:Key="MessageThicknessConverter" />
     <utilities:NotEmptyConverter x:Key="NotEmptyConverter" />
     <utilities:EmptyConverter x:Key="EmptyConverter" />
+    <utilities:NotEmptyBoolConverter x:Key="NotEmptyBoolConverter" />
     <utilities:ImagePathConverter x:Key="ImagePathConverter" />
     <utilities:NotNullConverter x:Key="NotNullConverter" />
     <utilities:NullConverter x:Key="NullConverter" />

--- a/slimCat/Utilities/Converters.cs
+++ b/slimCat/Utilities/Converters.cs
@@ -270,6 +270,21 @@ namespace slimCat.Utilities
         }
     }
 
+    /// <summary>
+    ///     If string is not empty, return true.
+    /// </summary>
+    public class NotEmptyBoolConverter : OneWayConverter
+    {
+        public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var parsed = (string)value;
+
+            return string.IsNullOrEmpty(parsed)
+                ? false
+                : true;
+        }
+    }
+
     public class CommaConverter : OneWayConverter
     {
         public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)

--- a/slimCat/Views/Channels/PMChannelView.xaml
+++ b/slimCat/Views/Channels/PMChannelView.xaml
@@ -55,7 +55,9 @@
         </DataTemplate>
 
         <DataTemplate DataType="{x:Type models:ProfileKink}">
-            <TextBlock Text="{Binding Name}" ToolTipService.ShowDuration="60000">
+            <TextBlock Text="{Binding Name}" ToolTipService.ShowDuration="60000"
+                       ToolTipService.IsEnabled="{Binding Tooltip,
+                                                  Converter={StaticResource NotEmptyBoolConverter}}">
                 <TextBlock.ToolTip>
                     <TextBlock Text="{Binding Tooltip}" TextWrapping="Wrap" MaxWidth="200" />
                 </TextBlock.ToolTip>
@@ -147,7 +149,8 @@
                                     Height="75"
                                     Width="75"
                                     Margin="0,10,0,0"
-                                    ToolTip="{Binding Path=Description}"/>
+                                    ToolTip="{Binding Path=Description}"
+                                    ToolTipService.IsEnabled="{Binding Path=Description, Converter={StaticResource NotEmptyBoolConverter}}"/>
                             </Grid>
                         </DataTemplate>
                     </Grid.Resources>


### PR DESCRIPTION
Yeah! I'm definitely gonna use that dictionary of func again in the future, I like it. In googling for help, I found a page where someone was really praising it. Another alternative I read about to switches is polymorphism, maybe for really big switches - I need to learn about that.

I initially tried to do this change using a style applied to all tooltips. It worked for image's tooltips, but couldn't get to work for kink's tooltips. I figure this way'll work anyway?
