### PR TITLE
"No toast or sound while DND" now works properly

### DIFF
--- a/slimCat/Services/NotificationService.cs
+++ b/slimCat/Services/NotificationService.cs
@@ -136,8 +136,9 @@ namespace slimCat.Services
 
         private void DingTheCrapOutOfTheUser()
         {
-            if ((DateTime.Now - lastDingLinged) <= TimeSpan.FromSeconds(1) || !ApplicationSettings.AllowSound)
-                return;
+            if ((DateTime.Now - lastDingLinged) <= TimeSpan.FromSeconds(1) || !ApplicationSettings.AllowSound
+                || (ApplicationSettings.DisallowNotificationsWhenDnd && ChatState.ChatModel.CurrentCharacter.Status == StatusType.Dnd))
+            { return; }
 
             Log("Playing sound");
             (new SoundPlayer(Environment.CurrentDirectory + @"\sounds\" + "newmessage.wav")).Play();
@@ -293,15 +294,17 @@ namespace slimCat.Services
 
         private void FlashWindow()
         {
-            if (!WindowIsFocused)
-            {
-                Log("Flashing window");
-                Application.Current.MainWindow.FlashWindow();
-            }
-            else
+            if (WindowIsFocused)
             {
                 Log("Wanted to flash window, but window was focused");
+                return;
             }
+            else if (ApplicationSettings.DisallowNotificationsWhenDnd
+                     && ChatState.ChatModel.CurrentCharacter.Status == StatusType.Dnd)
+            { return; }
+
+            Log("Flashing window");
+            Application.Current.MainWindow.FlashWindow();
         }
 
         private void HandleNewMessage(IMessage message)

--- a/slimCat/ViewModels/UI Parts/ToastNotificationsViewModel.cs
+++ b/slimCat/ViewModels/UI Parts/ToastNotificationsViewModel.cs
@@ -169,7 +169,7 @@ namespace slimCat.ViewModels
 
         public void ShowNotifications()
         {
-            if (ApplicationSettings.DisallowNotificationsWhenDnd && chatState.ChatModel.CurrentCharacter.Status == StatusType.Busy)
+            if (ApplicationSettings.DisallowNotificationsWhenDnd && chatState.ChatModel.CurrentCharacter.Status == StatusType.Dnd)
                 return;
 
             if (!ApplicationSettings.ShowNotificationsGlobal)


### PR DESCRIPTION
Before, it functioned while Busy instead of DND.
It now also correctly stops sound & window flashing. Yay!
