### PR TITLE
Options to hide login toasts & status change toasts

### DIFF
--- a/slimCat/Commands/Character/LogInCommand.cs
+++ b/slimCat/Commands/Character/LogInCommand.cs
@@ -40,7 +40,9 @@ namespace slimCat.Models
 
         public override void DisplayNewToast(IChatState chatState, IManageToasts toastsManager)
         {
-            if (!chatState.IsInteresting(Model.TargetCharacter.Name)) return;
+            if (!ApplicationSettings.ShowLoginToasts
+                || !chatState.IsInteresting(Model.TargetCharacter.Name))
+            { return; }
 
             DoNormalToast(toastsManager);
         }

--- a/slimCat/Commands/Character/StatusCommand.cs
+++ b/slimCat/Commands/Character/StatusCommand.cs
@@ -73,7 +73,9 @@ namespace slimCat.Models
 
             public override void DisplayNewToast(IChatState chatState, IManageToasts toastsManager)
             {
-                if (!chatState.IsInteresting(Model.TargetCharacter.Name)) return;
+                if (!ApplicationSettings.ShowStatusToasts
+                    || !chatState.IsInteresting(Model.TargetCharacter.Name))
+                { return; }
 
                 DoNormalToast(toastsManager);
             }

--- a/slimCat/Models/ApplicationSettings.cs
+++ b/slimCat/Models/ApplicationSettings.cs
@@ -90,6 +90,9 @@ namespace slimCat.Models
             ChannelDisplayThreshold = 5;
             AllowOfInterestColoring = true;
 
+            ShowStatusToasts = true;
+            ShowLoginToasts = true;
+
             ShowAvatarsInToasts = true;
             ShowNamesInToasts = true;
             ShowMessagesInToasts = true;
@@ -296,6 +299,10 @@ namespace slimCat.Models
         public static bool ToastsAreLocatedAtTop { get; set; }
 
         public static bool DisallowNotificationsWhenDnd { get; set; }
+
+        public static bool ShowLoginToasts { get; set; }
+
+        public static bool ShowStatusToasts { get; set; }
 
         public static bool ShowAvatarsInToasts { get; set; }
 

--- a/slimCat/ViewModels/Home Channel/HomeSettingsViewModel.cs
+++ b/slimCat/ViewModels/Home Channel/HomeSettingsViewModel.cs
@@ -497,6 +497,26 @@ namespace slimCat.ViewModels
             }
         }
 
+        public bool ShowLoginToasts
+        {
+            get { return ApplicationSettings.ShowLoginToasts; }
+            set
+            {
+                ApplicationSettings.ShowLoginToasts = value;
+                Save();
+            }
+        }
+
+        public bool ShowStatusToasts
+        {
+            get { return ApplicationSettings.ShowStatusToasts; }
+            set
+            {
+                ApplicationSettings.ShowStatusToasts = value;
+                Save();
+            }
+        }
+
         public bool ShowAvatarsInToasts
         {
             get { return ApplicationSettings.ShowAvatarsInToasts; }

--- a/slimCat/Views/Home Channel/HomeSettingsView.xaml
+++ b/slimCat/Views/Home Channel/HomeSettingsView.xaml
@@ -116,6 +116,20 @@
                 Display toast notifications for events
             </CheckBox>
 
+            <CheckBox IsChecked="{Binding ShowLoginToasts}"
+                      Visibility="{Binding ShowNotifications, Converter={StaticResource BoolConverter}}"
+                      Margin="25, 15, 0, 0"
+                      ToolTip="Allows slimCat to display notification windows that inform when a bookmarked or interesting person logs in or out.">
+                Display login and logout toasts
+            </CheckBox>
+
+            <CheckBox IsChecked="{Binding ShowStatusToasts}"
+                      Visibility="{Binding ShowNotifications, Converter={StaticResource BoolConverter}}"
+                      Margin="25, 15, 0, 0"
+                      ToolTip="Allows slimCat to display notification windows when a bookmarked or interesting person changes their status. Busy, Looking, etc.">
+                Display status change toasts
+            </CheckBox>
+
             <CheckBox IsChecked="{Binding ToastsAreLocatedAtTop}"
                       ToolTip="Allows slimCat to display notifications at the top right of your screen, instead of bottom-right.">
                 Display toast notifications at the top of the screen


### PR DESCRIPTION
Toasts dealing with leaving / entering channels, I figure, will be handled in the 'Default Channel Settings' options, yeah?
Also, as it is right now, these two options appear indented beneath the option "Display toast notifications for events," and only appear when that one is checked, sort of like a collapse.
