### PR TITLE
Fix for possible race condition and crash on character selection related to fetching profile data.

### DIFF
--- a/slimCat/Services/ProfileService.cs
+++ b/slimCat/Services/ProfileService.cs
@@ -75,7 +75,7 @@ namespace slimCat.Services
 
             container = contain;
 
-            events.GetEvent<CharacterSelectedLoginEvent>().Subscribe(GetProfileDataAsync);
+            events.GetEvent<LoginAuthenticatedEvent>().Subscribe(GetProfileDataAsync);
 
             var worker = new BackgroundWorker();
             worker.DoWork += GetKinkDataAsync;
@@ -279,6 +279,14 @@ namespace slimCat.Services
 
         public void GetProfileDataAsync(string character)
         {
+            var worker = new BackgroundWorker();
+            worker.DoWork += GetProfileDataAsyncHandler;
+            worker.RunWorkerAsync(character);
+        }
+
+        public void GetProfileDataAsync(bool? success)
+        {
+            var character = cm.CurrentCharacter.Name;
             var worker = new BackgroundWorker();
             worker.DoWork += GetProfileDataAsyncHandler;
             worker.RunWorkerAsync(character);


### PR DESCRIPTION
The profile data handler expects that the currently logged in character be accessible upon processing results,
and this constraint was violated when the chat server took too long to respond after character selection.
Fixed by switching the event handler to fire after the character has fully logged into the chat server.
