### PR TITLE
Channel header improvements

### DIFF
--- a/slimCat/ViewModels/Base Classes/ChannelViewModelBase.cs
+++ b/slimCat/ViewModels/Base Classes/ChannelViewModelBase.cs
@@ -51,6 +51,8 @@ namespace slimCat.ViewModels
 
         #region Fields
 
+        private GridLength headerRowHeight;
+
         private RelayCommand clear;
 
         private RelayCommand clearLog;
@@ -95,6 +97,7 @@ namespace slimCat.ViewModels
             errorRemoveTimer.AutoReset = false;
 
             entryBoxRowHeight = new GridLength(1, GridUnitType.Auto);
+            headerRowHeight = new GridLength(1, GridUnitType.Auto);
         }
 
         #endregion
@@ -104,6 +107,16 @@ namespace slimCat.ViewModels
         public ChannelSettingsModel ChannelSettings
         {
             get { return model.Settings; }
+        }
+
+        public GridLength HeaderRowHeight
+        {
+            get { return headerRowHeight; }
+            set
+            {
+                headerRowHeight = value;
+                OnPropertyChanged("HeaderRowHeight");
+            }
         }
 
         public ICommand ClearErrorCommand

--- a/slimCat/ViewModels/Channels/PMChannelViewModel.cs
+++ b/slimCat/ViewModels/Channels/PMChannelViewModel.cs
@@ -59,6 +59,8 @@ namespace slimCat.ViewModels
         private Timer cooldownTimer = new Timer(500);
         private ProfileImage currentImage;
 
+        private bool isCharacterStatusExpanded;
+
         private bool isInCoolDown;
 
         private bool isInNoteCoolDown;
@@ -169,6 +171,8 @@ namespace slimCat.ViewModels
                         UpdateProfileProperties();
                 };
 
+                isCharacterStatusExpanded = false;
+
                 LoggingSection = "pm channel vm";
             }
             catch (Exception ex)
@@ -236,6 +240,17 @@ namespace slimCat.ViewModels
         public bool HasStatus
         {
             get { return ConversationWith.StatusMessage.Length > 0; }
+        }
+
+        public bool IsCharacterStatusExpanded
+        {
+            get { return isCharacterStatusExpanded; }
+
+            set
+            {
+                isCharacterStatusExpanded = value;
+                OnPropertyChanged("IsCharacterStatusExpanded");
+            }
         }
 
         public bool IsTyping

--- a/slimCat/Views/Channels/GeneralChannelView.xaml
+++ b/slimCat/Views/Channels/GeneralChannelView.xaml
@@ -12,8 +12,8 @@
     <Grid Margin="10"
           TextBlock.FontSize="16">
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"
-                           x:Name="ChannelDescriptionRowDefinition"
+            <RowDefinition Height="{Binding Path=HeaderRowHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                           x:Name="HeaderRowDefinition"
                            MaxHeight="{Binding ActualHeight, RelativeSource={RelativeSource AncestorType=v:DisposableView}, Converter={StaticResource RemoveSomeConverter}, ConverterParameter=92}"
                            MinHeight="35" />
             <RowDefinition Height="*" />
@@ -23,7 +23,9 @@
         </Grid.RowDefinitions>
 
         <Grid>
-            <Expander IsExpanded="{Binding ShowChannelDescription}">
+            <Expander x:Name="ChannelDescriptionExpander"
+                      IsExpanded="{Binding ShowChannelDescription, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                      Collapsed="OnChannelDescriptionCollapsed" >
                 <Expander.Header>
                     <TextBlock Margin="0"
                                Foreground="{StaticResource ForegroundBrush}"
@@ -64,7 +66,9 @@
                                       DataContext="{Binding Path=ChannelSettings}" />
             </WrapPanel>
         </Grid>
-        <GridSplitter Grid.Row="1" MouseDoubleClick="OnChannelDescriptionResizeRequested" />
+        <GridSplitter Grid.Row="1"
+                      MouseDoubleClick="OnHeaderRowResizeRequested"
+                      DragDelta="OnHeaderRowDragging"/>
 
         <v:ObservingFlowDocumentReader
             Grid.Row="1"

--- a/slimCat/Views/Channels/GeneralChannelView.xaml.cs
+++ b/slimCat/Views/Channels/GeneralChannelView.xaml.cs
@@ -77,16 +77,30 @@ namespace slimCat.Views
             DataContext = null;
         }
 
-        private void OnChannelDescriptionResizeRequested(object sender, MouseButtonEventArgs e)
+        private void OnHeaderRowResizeRequested(object sender, MouseButtonEventArgs e)
         {
-            ChannelDescriptionRowDefinition.Height = new GridLength();
+            ChannelDescriptionExpander.IsExpanded = false;
         }
 
-        #endregion
+        private void OnChannelDescriptionCollapsed(object sender, RoutedEventArgs e)
+        {
+            HeaderRowDefinition.Height = new GridLength();
+        }
+
+        private void OnHeaderRowDragging(object sender, System.Windows.Controls.Primitives.DragDeltaEventArgs e)
+        {
+            if (HeaderRowDefinition.Height.Value == HeaderRowDefinition.MinHeight)
+                ChannelDescriptionExpander.IsExpanded = false;
+            else
+                ChannelDescriptionExpander.IsExpanded = true;
+        }
 
         private void OnEntryBoxResizeRequested(object sender, MouseButtonEventArgs e)
         {
             EntryBoxRowDefinition.Height = new GridLength();
         }
+
+        #endregion
+
     }
 }

--- a/slimCat/Views/Channels/PMChannelView.xaml
+++ b/slimCat/Views/Channels/PMChannelView.xaml
@@ -93,7 +93,8 @@
             <Grid>
                 <!-- Chat View Header -->
                 <Grid Visibility="{Binding IsViewingProfile, Converter={StaticResource OppositeBoolConverter}}">
-                    <Expander x:Name="CharacterStatusDisplayer">
+                    <Expander x:Name="CharacterStatusDisplayer"
+                              IsExpanded="{Binding Path=IsCharacterStatusExpanded}">
                         <Expander.Header>
                             <TextBlock TextWrapping="Wrap"
                                        TextAlignment="Left"


### PR DESCRIPTION
The channel description automatically expands and collapses appropriately when the header is dragged, and it remembers its position per channel / conversation. Yeehaw. :)
