### PR TITLE
Fixes option "notify messages mentioning my char"

### DIFF
--- a/slimCat/Services/NotificationService.cs
+++ b/slimCat/Services/NotificationService.cs
@@ -158,6 +158,8 @@ namespace slimCat.Services
 
             var temp = new List<string>(channel.Settings.EnumerableTerms);
             temp.AddRange(ApplicationSettings.GlobalNotifyTermsList);
+            if (ApplicationSettings.CheckForOwnName)
+                temp.Add(cm.CurrentCharacter.Name.ToLower());
 
             var checkAgainst = temp.Distinct(StringComparer.OrdinalIgnoreCase).Select(x => x.Trim());
 
@@ -239,23 +241,6 @@ namespace slimCat.Services
                     message.IsOfInterest = true;
                     return;
                 }
-            }
-
-            if (ApplicationSettings.CheckForOwnName)
-            {
-                // Now our character's name is always added
-                var name = cm.CurrentCharacter.Name.ToLower();
-
-                temp.Add(name); // fixes an issue where a user's name would ding constantly
-                if (name.Last() != 's' && name.Last() != 'z')
-                    temp.Add(name + @"'s"); // possessive fix
-                else
-                {
-                    temp.Add(name + @"'");
-                    temp.Add(name + "'s");
-                }
-
-                checkAgainst = temp.Distinct(StringComparer.OrdinalIgnoreCase);
             }
 
             {


### PR DESCRIPTION
With the old code, I couldn't get the option to work under any condition. The variables `temp` and `checkAgainst` weren't used after that, which makes me think it was left behind after code around it was changed. I tested out possessives and they seemed to work alright this way.
