### PR TITLE
Fixed dragging conversation tabs

### DIFF
--- a/slimCat/Views/User Bar/UserbarView.xaml.cs
+++ b/slimCat/Views/User Bar/UserbarView.xaml.cs
@@ -43,6 +43,7 @@ namespace slimCat.Views
         private readonly UserbarViewModel vm;
 
         private Point lastPoint;
+        private ListBoxItem draggedItem;
 
         #endregion
 
@@ -66,7 +67,7 @@ namespace slimCat.Views
 
         private void OnPreviewMouseClick(object sender, MouseEventArgs e)
         {
-            var draggedItem = sender as ListBoxItem;
+            draggedItem = sender as ListBoxItem;
             if (draggedItem == null) return;
             if (e.LeftButton != MouseButtonState.Pressed) return;
             if (e.OriginalSource is Rectangle) return;
@@ -139,7 +140,6 @@ namespace slimCat.Views
 
         private void OnMouseMove(object sender, MouseEventArgs e)
         {
-            var draggedItem = sender as ListBoxItem;
             if (draggedItem == null) return;
             if (e.LeftButton != MouseButtonState.Pressed) return;
             if (e.OriginalSource is Rectangle) return;
@@ -149,6 +149,7 @@ namespace slimCat.Views
             if (Math.Abs(lastPoint.Y - current.Y) >= minDragDistance)
             {
                 DragDrop.DoDragDrop(draggedItem, draggedItem.DataContext, DragDropEffects.Move);
+                draggedItem = null;
             }
         }
     }


### PR DESCRIPTION
Yay, an easy one! Assuming I got it right.

I realized that when dragging a tab, an error surrounding the minDragDistance was occuring. You'd click-and-hold a tab near the edge of another tab, then "drag" into that nearby tab. However, the drag only actually started after the minDragDistance, causing you to drag the nearby tab instead of the one you clicked on.

So this change is keeping track of the tab you clicked on.
