### PR TITLE
Improves chat header & entrybox resizing

### DIFF
--- a/slimCat/Theme/EmbeddedTheme.xaml
+++ b/slimCat/Theme/EmbeddedTheme.xaml
@@ -32,6 +32,7 @@
     <utilities:CacheUriForeverConverter x:Key="CacheUriForeverConverter" />
     <utilities:AutoOrStarConverter x:Key="AutoOrStarConverter" />
     <utilities:RemoveSomeConverter x:Key="RemoveSomeConverter" />
+    <utilities:ReduceRowConverter x:Key="ReduceRowConverter" />
     <utilities:EqualsConverter x:Key="EqualsConverter" />
 
     <utilities:ConverterChain x:Key="EqualsVisibilityConverterChain">

--- a/slimCat/Utilities/Converters.cs
+++ b/slimCat/Utilities/Converters.cs
@@ -1878,6 +1878,14 @@ namespace slimCat.Utilities
         }
     }
 
+    public class ReduceRowConverter : OneWayMultiConverter
+    {
+        public override object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            return Math.Max(((double)values[0] * 0.8) - ((double)values[1]) - (System.Convert.ToDouble(parameter)), 0);
+        }
+    }
+
     /// <summary>Represents a chain of <see cref="IValueConverter" />s to be executed in succession.</summary>
     [ContentProperty("Converters")]
     [ContentWrapper(typeof (ValueConverterCollection))]

--- a/slimCat/Views/Channels/GeneralChannelView.xaml
+++ b/slimCat/Views/Channels/GeneralChannelView.xaml
@@ -14,18 +14,32 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="{Binding Path=HeaderRowHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                            x:Name="HeaderRowDefinition"
-                           MaxHeight="{Binding ActualHeight, RelativeSource={RelativeSource AncestorType=v:DisposableView}, Converter={StaticResource RemoveSomeConverter}, ConverterParameter=92}"
-                           MinHeight="35" />
+                           MinHeight="35">
+                <RowDefinition.MaxHeight>
+                    <MultiBinding
+                         Converter="{StaticResource ReduceRowConverter}" ConverterParameter="20">
+                        <Binding RelativeSource="{RelativeSource AncestorType=v:DisposableView}" Path="ActualHeight" />
+                        <Binding ElementName="EntryBoxRowGrid" Path="ActualHeight" />
+                    </MultiBinding>
+                </RowDefinition.MaxHeight>
+            </RowDefinition>
             <RowDefinition Height="*" />
             <RowDefinition Height="{Binding Path=EntryBoxRowHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                           x:Name="EntryBoxRowDefinition"
-                           MaxHeight="{Binding ActualHeight, RelativeSource={RelativeSource AncestorType=v:DisposableView}, Converter={StaticResource RemoveSomeConverter}, ConverterParameter=60}" />
+                           x:Name="EntryBoxRowDefinition">
+                <RowDefinition.MaxHeight>
+                    <MultiBinding
+                         Converter="{StaticResource ReduceRowConverter}" ConverterParameter="0">
+                        <Binding RelativeSource="{RelativeSource AncestorType=v:DisposableView}" Path="ActualHeight" />
+                        <Binding ElementName="HeaderRowGrid" Path="ActualHeight" />
+                    </MultiBinding>
+                </RowDefinition.MaxHeight>
+            </RowDefinition>
         </Grid.RowDefinitions>
 
-        <Grid>
+        <Grid x:Name="HeaderRowGrid">
             <Expander x:Name="ChannelDescriptionExpander"
                       IsExpanded="{Binding ShowChannelDescription, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                      Collapsed="OnChannelDescriptionCollapsed" >
+                      Collapsed="OnChannelDescriptionCollapsed">
                 <Expander.Header>
                     <TextBlock Margin="0"
                                Foreground="{StaticResource ForegroundBrush}"
@@ -38,8 +52,14 @@
                         <Run Text="{Binding Path=ChatContentString, Mode=OneWay}" />
                     </TextBlock>
                 </Expander.Header>
-                <ScrollViewer
-                    MaxHeight="{Binding ActualHeight, RelativeSource={RelativeSource AncestorType=v:DisposableView}, Converter={StaticResource RemoveSomeConverter}, ConverterParameter=90}">
+                <ScrollViewer>
+                    <ScrollViewer.MaxHeight>
+                        <MultiBinding
+                            Converter="{StaticResource ReduceRowConverter}" ConverterParameter="60">
+                            <Binding RelativeSource="{RelativeSource AncestorType=v:DisposableView}" Path="ActualHeight" />
+                            <Binding ElementName="EntryBoxRowGrid" Path="ActualHeight" />
+                        </MultiBinding>
+                    </ScrollViewer.MaxHeight>
                     <TextBlock Margin="0"
                                FontSize="{Binding Source={x:Static models:ApplicationSettings.FontSize}}"
                                Foreground="{StaticResource ForegroundBrush}"
@@ -113,7 +133,8 @@
 
         <GridSplitter Grid.Row="2" MouseDoubleClick="OnEntryBoxResizeRequested" />
 
-        <Grid Grid.Row="2"
+        <Grid x:Name="EntryBoxRowGrid"
+              Grid.Row="2"
               Height="auto"
               Margin="0,4,0,0"
               MaxHeight="{Binding ActualHeight, RelativeSource={RelativeSource AncestorType=v:DisposableView}, Converter={StaticResource RemoveSomeConverter}, ConverterParameter=65}">

--- a/slimCat/Views/Channels/PMChannelView.xaml
+++ b/slimCat/Views/Channels/PMChannelView.xaml
@@ -79,7 +79,7 @@
             <RowDefinition />
             <RowDefinition Height="{Binding Path=EntryBoxRowHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                            x:Name="EntryBoxRowDefinition"
-                           MaxHeight="{Binding ActualHeight, RelativeSource={RelativeSource AncestorType=v:DisposableView}, Converter={StaticResource RemoveSomeConverter}, ConverterParameter=60}" />
+                           MaxHeight="{Binding ActualHeight, RelativeSource={RelativeSource AncestorType=v:DisposableView}, Converter={StaticResource RemoveSomeConverter}, ConverterParameter=200}" />
         </Grid.RowDefinitions>
 
         <Border BorderBrush="{StaticResource HighlightBrush}"


### PR DESCRIPTION
I was hoping I could do this in a less bulky way, but still pretty good I think... I really like how this works.

This one does a few things:
1. Fixes a bug where channel description's `ScrollViewer` could be taller than the area it fits in, causing the last couple lines of the description to be unreadable
2. Ensures that when the entry box & chat header grow, at least a couple lines of chat are always visible, to prevent disorientation. (I tried `MinHeight` for this, but couldn't get the `GridSplitter`s to play nice with that)
3. Ensures that the header can never shrink the entry box, but the opposite can occur
