### PR TITLE
Fix "/my" and "/me's" commands

### DIFF
--- a/slimCat/ViewModels/Base Classes/ChannelViewModelBase.cs
+++ b/slimCat/ViewModels/Base Classes/ChannelViewModelBase.cs
@@ -342,6 +342,11 @@ namespace slimCat.ViewModels
 
             if (CommandParser.HasNonCommand(Message))
             {
+                if (Message.StartsWith("/my "))
+                    Message = "/me 's " + Message.Substring("/my ".Length);
+                else if (Message.StartsWith("/me's "))
+                    Message = "/me 's " + Message.Substring("/me's ".Length);
+
                 SendMessage();
                 return;
             }


### PR DESCRIPTION
Tested all the non-command commands in both PMs and channels, to make sure.
