### PR TITLE
Fixes caret position when pasting a URL

### DIFF
--- a/slimCat/Views/UI Parts/ChannelTextBoxEntryView.xaml.cs
+++ b/slimCat/Views/UI Parts/ChannelTextBoxEntryView.xaml.cs
@@ -94,8 +94,9 @@ namespace slimCat.Views
             if (string.IsNullOrWhiteSpace(Entry.SelectedText))
             {
                 var formattedPaste = "[url={0}][/url]".FormatWith(pasteText);
+                var caretPasteIndex = Entry.CaretIndex;
                 Entry.Text = Entry.Text.Insert(Entry.CaretIndex, formattedPaste);
-                Entry.CaretIndex += formattedPaste.IndexOf("[/url]", StringComparison.Ordinal);
+                Entry.CaretIndex = caretPasteIndex + formattedPaste.IndexOf("[/url]", StringComparison.Ordinal);
             }
             else
             {


### PR DESCRIPTION
For some reason, the `Entry.CaretIndex +=` was adding from 0 instead of the index of the caret.