### PR TITLE
Fixes my goof where filled entrybox resized poorly

### DIFF
--- a/slimCat/Views/Channels/GeneralChannelView.xaml
+++ b/slimCat/Views/Channels/GeneralChannelView.xaml
@@ -25,15 +25,8 @@
             </RowDefinition>
             <RowDefinition Height="*" />
             <RowDefinition Height="{Binding Path=EntryBoxRowHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                           x:Name="EntryBoxRowDefinition">
-                <RowDefinition.MaxHeight>
-                    <MultiBinding
-                         Converter="{StaticResource ReduceRowConverter}" ConverterParameter="0">
-                        <Binding RelativeSource="{RelativeSource AncestorType=v:DisposableView}" Path="ActualHeight" />
-                        <Binding ElementName="HeaderRowGrid" Path="ActualHeight" />
-                    </MultiBinding>
-                </RowDefinition.MaxHeight>
-            </RowDefinition>
+                           x:Name="EntryBoxRowDefinition"
+                           MaxHeight="{Binding ActualHeight, RelativeSource={RelativeSource AncestorType=v:DisposableView}, Converter={StaticResource RemoveSomeConverter}, ConverterParameter=160}" />
         </Grid.RowDefinitions>
 
         <Grid x:Name="HeaderRowGrid">

--- a/slimCat/Views/Channels/PMChannelView.xaml
+++ b/slimCat/Views/Channels/PMChannelView.xaml
@@ -79,7 +79,7 @@
             <RowDefinition />
             <RowDefinition Height="{Binding Path=EntryBoxRowHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                            x:Name="EntryBoxRowDefinition"
-                           MaxHeight="{Binding ActualHeight, RelativeSource={RelativeSource AncestorType=v:DisposableView}, Converter={StaticResource RemoveSomeConverter}, ConverterParameter=200}" />
+                           MaxHeight="{Binding ActualHeight, RelativeSource={RelativeSource AncestorType=v:DisposableView}, Converter={StaticResource RemoveSomeConverter}, ConverterParameter=160}" />
         </Grid.RowDefinitions>
 
         <Border BorderBrush="{StaticResource HighlightBrush}"

--- a/slimCat/Views/UI Parts/ChannelTextBoxEntryView.xaml
+++ b/slimCat/Views/UI Parts/ChannelTextBoxEntryView.xaml
@@ -15,7 +15,8 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="{Binding ShowPreview, Converter={StaticResource AutoOrStarConverter}}" />
-            <RowDefinition Height="*" />
+            <RowDefinition Height="*"
+                           MaxHeight="{Binding ActualHeight, RelativeSource={RelativeSource AncestorType=v:DisposableView}, Converter={StaticResource RemoveSomeConverter}, ConverterParameter=200}"/>
         </Grid.RowDefinitions>
 
         <DockPanel Visibility="{Binding Error, Mode=OneWay, Converter={StaticResource EmptyConverter}}">


### PR DESCRIPTION
What happened was, the `ChannelView's Grid` grew to its `MaxHeight` and stopped growing, but the `TextBoxEntryView's Grid` kept growing, causing its last few lines to be unreadable. So adding a `MaxHeight` to it fixed that.