### PR TITLE
Fixes bug from previous commit

### DIFF
--- a/slimCat/ViewModels/Channels/PMChannelViewModel.cs
+++ b/slimCat/ViewModels/Channels/PMChannelViewModel.cs
@@ -496,6 +496,9 @@ namespace slimCat.ViewModels
         {
             get
             {
+                if (model.ProfileData == null)
+                    return new ICharacter[0];
+
                 var toReturn = model.ProfileData.Alts
                     .Select(x => CharacterManager.Find(x))
                     .ToList();
@@ -737,6 +740,8 @@ namespace slimCat.ViewModels
 
             if (e.PropertyName == "ProfileData")
             {
+                OnPropertyChanged("AltCharacters");
+
                 if (ChatModel.CurrentCharacterData == null)
                 {
                     profileService.GetProfileDataAsync(ChatModel.CurrentCharacter.Name);

--- a/slimCat/Views/Channels/PMChannelView.xaml
+++ b/slimCat/Views/Channels/PMChannelView.xaml
@@ -373,7 +373,7 @@
 
                                 <Expander Header="Other Characters"
                                           Visibility="{Binding Model.ProfileData.Alts.Count, Converter={StaticResource GreaterThanZeroConverter}}">
-                                    <ItemsControl ItemsSource="{Binding AltCharacters}"
+                                    <ItemsControl ItemsSource="{Binding AltCharacters, UpdateSourceTrigger=PropertyChanged}"
                                                   HorizontalAlignment="Left"
                                                   VerticalContentAlignment="Top"
                                                   HorizontalContentAlignment="Left"


### PR DESCRIPTION
Got it! You were right, I checked that area, and the `AltCharacters get` was only running once, early, before the ProfileData was downloaded. So using `OnPropertyChanged` fixed that.

The `GetAvatar` is fortunately super-cool. You can view the blank undownloaded icons, and they appear the moment they download.

I tested this pretty thoroughly now - I'm pretty happy, feeling that more bugs there are pretty unlikely.