### PR TITLE
Fixed '/say /foobar' not showing ':' after name

### DIFF
--- a/slimCat/Utilities/Converters.cs
+++ b/slimCat/Utilities/Converters.cs
@@ -1355,7 +1355,10 @@ namespace slimCat.Utilities
                 else if (command == 'm')  // is an emote
                     inlines.Add(new Italic(Parse(text)));
                 else
+                {
+                    inlines.Add(new Run(" : "));
                     inlines.Add(Parse(text));
+                }
 
                 return inlines;
             }


### PR DESCRIPTION
Tested with Obsi -
> Obsi : foobar
> Obsi : I did '/say foobar' there
> Obsi : /foobar
> Obsi : And '/say /foobar'