### PR TITLE
Heart tab filters statuses for all collapses

### DIFF
--- a/slimCat/Theme/EmbeddedTheme.xaml
+++ b/slimCat/Theme/EmbeddedTheme.xaml
@@ -214,6 +214,19 @@
         </StackPanel>
     </ControlTemplate>
 
+    <ControlTemplate x:Key="StatusCheckBoxes" TargetType="ContentControl"
+                     d:DataContext="{d:DesignInstance models:GenericSearchSettingsModel}">
+        <StackPanel Orientation="Vertical">
+            <TextBlock Foreground="{StaticResource ForegroundBrush}"
+                       Text="Who are ..."
+                       Margin="2,0" />
+            <CheckBox IsChecked="{Binding ShowLooking}">Looking For Play</CheckBox>
+            <CheckBox IsChecked="{Binding ShowNormal}">Just Online</CheckBox>
+            <CheckBox IsChecked="{Binding ShowBusyAway}">Busy or Away</CheckBox>
+            <CheckBox IsChecked="{Binding ShowDnd}">DND</CheckBox>
+        </StackPanel>
+    </ControlTemplate>
+
     <Style x:Key="ActivatingToggleButton"
            TargetType="ToggleButton"
            BasedOn="{StaticResource ImageContentToggleButton}">

--- a/slimCat/ViewModels/Channel Bar/ManageListsViewModel.cs
+++ b/slimCat/ViewModels/Channel Bar/ManageListsViewModel.cs
@@ -285,8 +285,7 @@ namespace slimCat.ViewModels
 
         private bool MeetsFilter(ICharacter character)
         {
-            return character.MeetsFilters(
-                GenderSettings, SearchSettings, CharacterManager, ChatModel.CurrentChannel as GeneralChannelModel);
+            return SearchSettings.MeetsStatusFilter(character);
         }
 
         private IEnumerable<ICharacter> GetList(ICharacterManager manager, ListKind listKind, bool onlineOnly = true)

--- a/slimCat/Views/Channel Bar/ManageListsView.xaml
+++ b/slimCat/Views/Channel Bar/ManageListsView.xaml
@@ -76,7 +76,7 @@
                         <ContentControl Template="{StaticResource GenderCheckBoxes}"
                                         DataContext="{Binding Path=GenderSettings}" />
 
-                        <ContentControl Template="{StaticResource GeneralFilterCheckBoxes}"
+                        <ContentControl Template="{StaticResource StatusCheckBoxes}"
                                         DataContext="{Binding Path=SearchSettings}" />
 
                         <CheckBox Content="Offline"


### PR DESCRIPTION
I tried out a couple ideas for this, and I think this one makes the most sense -
In the heart tab only, any filters for which there are already collapses are removed. `Friends`, `Bookmarks`, `Mods`, `Interested`, `Not Interested` and `Ignored`. That just leaves the Gender and Status filters.

Those other filters didn't seem very useful to me, and I couldn't find a way to make them work that wasn't buggy in another way. The shorter filter list is quicker & easier to use, I think.

The main use of course is that now the status filters function for all lists properly! Very nice for finding friends and bookmarks who are Looking.