### PR TITLE
Fixes vanishing kinks in profiles

### DIFF
--- a/slimCat/ViewModels/Channels/PMChannelViewModel.cs
+++ b/slimCat/ViewModels/Channels/PMChannelViewModel.cs
@@ -128,7 +128,8 @@ namespace slimCat.ViewModels
                     OnPropertyChanged("CanShowNoteTimeLeft");
                 };
 
-                AllKinks = new ListCollectionView(new ProfileKink[0]);
+                if (AllKinks == null)
+                    AllKinks = new ListCollectionView(new ProfileKink[0]);
 
                 noteCooldownUpdateTick.Elapsed += (s, e) => OnPropertyChanged("NoteTimeLeft");
 


### PR DESCRIPTION
You can reproduce it by opening someone's profile, closing their conversation tab, then opening the profile again. 9 times out of 10 when you did this, the kinks didn't appear.