### PR TITLE
Reduce jitter when right-click menu's avatar loads

### DIFF
--- a/slimCat/Views/UI Parts/RightClickMenu.xaml
+++ b/slimCat/Views/UI Parts/RightClickMenu.xaml
@@ -31,8 +31,8 @@
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
                     
-                    <Border MaxHeight="75" 
-                            MaxWidth="75" 
+                    <Border Height="75" 
+                            Width="75" 
                             Margin="0,0,10,0"
                             Visibility="{Binding Source={x:Static models:ApplicationSettings.ShowAvatars}, Converter={StaticResource BoolConverter}}">
                         <Image Source="{Binding Path=Target.Avatar}"/>


### PR DESCRIPTION
A really small detail, but one that I like anyway!
When the avatar loads, everything in the menu shifts. This stops that. Most noticeable when the servers are slow.
Tested to make sure it doesn't change how it looks when `ShowAvatars` is off.