### PR TITLE
Fixes scrolling for non-standard mousewheels

### DIFF
--- a/slimCat/Utilities/StaticFunctions.cs
+++ b/slimCat/Utilities/StaticFunctions.cs
@@ -462,7 +462,7 @@ namespace slimCat.Utilities
             var lineSize = (fontSize * 0.89d) + 9.72d;
 
             // 120 is standard for one mousewheel tick
-            return ((scrollTicks / 120) * linesPerTick * lineSize);
+            return ((scrollTicks / 120.0d) * linesPerTick * lineSize);
         }
 
     }


### PR DESCRIPTION
Woops, little thing! So, somebody was complaining that their scrollwheel wasn't scrolling at all. I think the `scrollTicks / 120` was resulting in an int, and needs to result in a double. `80 / 120.0d` worked fine, while `80 / 120` didn't, so I think this fixes it.