### PR TITLE
Fix "Open log folder" button for portable mode

### DIFF
--- a/slimCat/Services/LoggingService.cs
+++ b/slimCat/Services/LoggingService.cs
@@ -67,8 +67,14 @@ namespace slimCat.Services
         {
             CurrentCharacter = character;
 
-            FullPath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "slimCat", CurrentCharacter);
+            if (!ApplicationSettings.PortableMode)
+                FullPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "slimCat", CurrentCharacter);
+            else
+            {
+                var exeFolder = (new FileInfo(System.Reflection.Assembly.GetEntryAssembly().Location)).Directory.ToString();
+                FullPath = Path.Combine(exeFolder, "logs", CurrentCharacter);
+            }
 
             if (!Directory.Exists(FullPath))
                 Directory.CreateDirectory(FullPath);


### PR DESCRIPTION
So I tested to make sure all of the following is good:
1) Both `log folder` and `log file` buttons work properly
2) Both PMs and channels work
3) Both portable mode & normal mode work
4) Also tested running the program from a shortcut in a different folder

The bit for assigning `exeFolder` I found in a stackOverflow page, and it seemed like the best one I could find, but let me know if there's a better way for that, or anything else here!