### PR TITLE
Fix crash with notification removals

### DIFF
--- a/slimCat/Utilities/FilteredCollection.cs
+++ b/slimCat/Utilities/FilteredCollection.cs
@@ -147,9 +147,7 @@ namespace slimCat.Utilities
 
                 case NotifyCollectionChangedAction.Remove:
                 {
-                    var items = e.OldItems.Cast<T>();
-
-                    items.Each(item => Collection.Remove(item));
+                    e.OldItems.OfType<T>().Each(item => Collection.Remove(item));
                     break;
                 }
             }

--- a/slimCat/Utilities/FilteredCollection.cs
+++ b/slimCat/Utilities/FilteredCollection.cs
@@ -147,10 +147,9 @@ namespace slimCat.Utilities
 
                 case NotifyCollectionChangedAction.Remove:
                 {
-                    if (e.OldStartingIndex == -1 || Collection.Count == 0)
-                        return;
+                    var items = e.OldItems.Cast<T>();
 
-                    Collection.RemoveAt(e.OldStartingIndex);
+                    items.Each(item => Collection.Remove(item));
                     break;
                 }
             }


### PR DESCRIPTION
This one was really tricky to figure out, because the stacktrace doesn't really give you a filename + line number to work with!

To duplicate the crash, go to your notifications tab and type in a filter that successfully filters out some of the notifications. Then click the little "Close This Element" buttons until it crashes. I believe it always crashes when there's only 1 element left.

```
Exception: Index was out of range. Must be non-negative and less than the size of the collection.
Parameter name: index
Occured at: mscorlib

Immediate stack trace: Void RemoveAt(Int32)   at System.Collections.ObjectModel.Collection'1.RemoveAt(Int32 index)
   at System.Collections.Specialized.NotifyCollectionChangedEventHandler.Invoke(Object sender, NotifyCollectionChangedEventArgs e)
   at System.Collections.ObjectModel.ObservableCollection`1.OnCollectionChanged(NotifyCollectionChangedEventArgs e)
   at System.Windows.Controls.Button.OnClick()
...
```

I'm not completely confident about this code, though it seems okay in testing - I just mimiced the `
case NotifyCollectionChangedAction.Add:` right above this change.