### PR TITLE
Connection Strength Bars tweak

### DIFF
--- a/slimCat/Theme/EmbeddedTheme.xaml
+++ b/slimCat/Theme/EmbeddedTheme.xaml
@@ -12,6 +12,7 @@
 
     <BooleanToVisibilityConverter x:Key="BoolConverter" />
     <utilities:OppositeBoolConverter x:Key="OppositeBoolConverter" />
+    <utilities:HiddenBoolConverter x:Key="HiddenBoolConverter" />
     <utilities:BoolColorConverter x:Key="ColorConverter" />
     <utilities:GenderImageConverter x:Key="GenderImageConverter" />
     <utilities:ChannelTypeToImageConverter x:Key="ChannelTypeToImageConverter" />

--- a/slimCat/Utilities/Converters/HiddenBoolConverter.cs
+++ b/slimCat/Utilities/Converters/HiddenBoolConverter.cs
@@ -1,0 +1,37 @@
+#region Copyright
+
+// <copyright file="HiddenBoolConverter.cs">
+//     Copyright (c) 2013-2015, Justin Kadrovach, All rights reserved.
+// 
+//     This source is subject to the Simplified BSD License.
+//     Please see the License.txt file for more information.
+//     All other rights reserved.
+// 
+//     THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY
+//     KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+//     IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+//     PARTICULAR PURPOSE.
+// </copyright>
+
+#endregion
+
+namespace slimCat.Utilities
+{
+    #region Usings
+
+    using System.Windows;
+
+    #endregion
+
+    /// <summary>
+    ///     Like BoolConverter, except returns hidden instead of collapsed
+    /// </summary>
+    public class HiddenBoolConverter : OneWayConverter
+    {
+        public override object Convert(object value, object paramater)
+        {
+            var v = (bool) value;
+            return !v ? Visibility.Hidden : Visibility.Visible;
+        }
+    }
+}

--- a/slimCat/Views/User Bar/UserbarView.xaml
+++ b/slimCat/Views/User Bar/UserbarView.xaml
@@ -113,13 +113,13 @@
                                     </Style>
                                 </WrapPanel.Resources>
                                 <Rectangle Height="3"
-                                           Visibility="{Binding Path=ConnectionIsConnected, Mode=OneWay, Converter={StaticResource BoolConverter}}" />
+                                           Visibility="{Binding Path=ConnectionIsConnected, Mode=OneWay, Converter={StaticResource HiddenBoolConverter}}" />
                                 <Rectangle Height="6"
-                                           Visibility="{Binding Path=ConnectionIsModerate, Mode=OneWay, Converter={StaticResource BoolConverter}}" />
+                                           Visibility="{Binding Path=ConnectionIsModerate, Mode=OneWay, Converter={StaticResource HiddenBoolConverter}}" />
                                 <Rectangle Height="10"
-                                           Visibility="{Binding Path=ConnectionIsGood, Mode=OneWay, Converter={StaticResource BoolConverter}}" />
+                                           Visibility="{Binding Path=ConnectionIsGood, Mode=OneWay, Converter={StaticResource HiddenBoolConverter}}" />
                                 <Rectangle Height="15"
-                                           Visibility="{Binding Path=ConnectionIsPerfect, Mode=OneWay, Converter={StaticResource BoolConverter}}" />
+                                           Visibility="{Binding Path=ConnectionIsPerfect, Mode=OneWay, Converter={StaticResource HiddenBoolConverter}}" />
                                 <TextBlock
                                     Visibility="{Binding Path=IsDisconnected, Mode=OneWay, Converter={StaticResource BoolConverter}}"
                                     Foreground="{StaticResource ContrastBrush}"

--- a/slimCat/slimCat.csproj
+++ b/slimCat/slimCat.csproj
@@ -279,6 +279,7 @@
     <Compile Include="Utilities\Converters\BbCodeBaseConverter.cs" />
     <Compile Include="Utilities\Converters\BbCodeConverter.cs" />
     <Compile Include="Utilities\Converters\BbCodePostConverter.cs" />
+    <Compile Include="Utilities\Converters\HiddenBoolConverter.cs" />
     <Compile Include="Utilities\Extensions\DateTimeExtensions.cs" />
     <Compile Include="Utilities\Enums\BbCodeType.cs" />
     <Compile Include="Utilities\Converters\BbFlowConverter.cs" />


### PR DESCRIPTION
So whenever the connection strength changed, the size of the UserBar
View changed and the whole interface would shift over a bit. This
started to annoy me so here's a try at fixing it, using
Visibility.Hidden instead of Visibility.Collapsed.

As before, let me know if anything different / more should be done! Be
picky if you feel like it