### PR TITLE
Changed Logs to Year-Month-Day

### DIFF
--- a/slimCat/Services/LoggingService.cs
+++ b/slimCat/Services/LoggingService.cs
@@ -226,7 +226,7 @@ namespace slimCat.Services
             var year = time.Year;
             var day = time.Day;
 
-            return month + "-" + day + "-" + year + ".txt";
+            return year + "-" + month + "-" + day + ".txt";
         }
 
         private StreamWriter AccessLog(string title, string id)


### PR DESCRIPTION
Year-month-day.txt makes a lot more sense from a logs standpoint than
month-day-year.txt as it is now.  This allows logs to be naturally
sorted by sorting alphabetically and prevents the mixing of years as
time goes on.