### PR TITLE
adjust chat stats url per update

### DIFF
--- a/slimCat/Views/Full Screen/LoginView.xaml
+++ b/slimCat/Views/Full Screen/LoginView.xaml
@@ -62,7 +62,7 @@
         <WrapPanel Orientation="Horizontal"
                    HorizontalAlignment="Center">
             <TextBlock>
-                <Hyperlink CommandParameter="http://chat.f-list.net:9002/stats/">Chat Stats</Hyperlink>
+                <Hyperlink CommandParameter="https://chat.f-list.net/stats/">Chat Stats</Hyperlink>
             </TextBlock>
             <TextBlock Visibility="{Binding Path=HasNewUpdate, Converter={StaticResource BoolConverter}}"
                        Margin="15,0,0,0">


### PR DESCRIPTION
http itself doesn't work, so https is mandatory. Update per new stats link in newspost. 